### PR TITLE
COMP: Updating the Slicer tag to the nightly of Sept 13

### DIFF
--- a/CMake/Superbuild/External_Slicer.cmake
+++ b/CMake/Superbuild/External_Slicer.cmake
@@ -112,7 +112,7 @@ if(NOT DEFINED ${proj}_DIR)
     set(${proj}_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
     list(APPEND ${proj}_EP_ARGS
       GIT_REPOSITORY ${git_protocol}://github.com/Slicer/Slicer.git
-      GIT_TAG acf259aa78918db904668f8779a2b22f21559585
+      GIT_TAG cb1c7208464d13fb337659dadc62af7ee6fc25f4 # Slicer tag as of Sept-13-2017
       )
   endif()
 

--- a/CMake/Superbuild/External_SlicerSALT.cmake
+++ b/CMake/Superbuild/External_SlicerSALT.cmake
@@ -22,7 +22,7 @@
 set(proj SlicerSALT)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES VTKv7 ITKv4)
+set(${proj}_DEPENDENCIES VTKv8 ITKv4)
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)


### PR DESCRIPTION
@laurapascal : Could you please check if SPHARM and Shape population viewer run correctly under these changes? With this change, VTK8 would be compiled and used for all the extensions. 