### PR TITLE
Fixing of Data Importer Module

### DIFF
--- a/CMake/Superbuild/External_SPHARM-PDM.cmake
+++ b/CMake/Superbuild/External_SPHARM-PDM.cmake
@@ -52,7 +52,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/NIRALUser/SPHARM-PDM.git"
-    GIT_TAG "8221677d286401356fb2cad840843629ec455850"
+    GIT_TAG "01a7598c2ce76dd2749d53e43878330be59b63a6"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${${proj}_DIR}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build ${${proj}_PACKAGE_DIR} --config ${config} --target package

--- a/Modules/Scripted/ShapeAnalysisToolBox/CommonUtilities/utility.py
+++ b/Modules/Scripted/ShapeAnalysisToolBox/CommonUtilities/utility.py
@@ -32,23 +32,23 @@ class MRMLUtility(object):
 
     @staticmethod
     def createNewMRMLNode(node_name, mrml_type, copy_node=None, transform=None):
-        mrml_node = slicer.mrmlScene.AddNewNodeByClass(mrml_type)
+        mrml_node = slicer.mrmlScene.AddNode(mrml_type)
         if copy_node is not None:
             mrml_node.Copy(copy_node)
-            if mrml_type is 'vtkMRMLModelNode':
+            if mrml_type.GetClassName() is 'vtkMRMLModelNode':
                 display_node = slicer.mrmlScene.CreateNodeByClass('vtkMRMLModelDisplayNode')
                 slicer.mrmlScene.AddNode(display_node)
                 display_node.UnRegister(slicer.mrmlScene)
                 mrml_node.SetAndObserveDisplayNodeID(display_node.GetID())
                 mrml_node.SetAndObserveStorageNodeID(None)
-            elif mrml_type is 'vtkMRMLMarkupsFiducialNode':
+            elif mrml_type.GetClassName() is 'vtkMRMLMarkupsFiducialNode':
                 display_node = slicer.mrmlScene.CreateNodeByClass('vtkMRMLMarkupsDisplayNode')
                 slicer.mrmlScene.AddNode(display_node)
                 display_node.UnRegister(slicer.mrmlScene)
                 mrml_node.SetAndObserveDisplayNodeID(display_node.GetID())
                 mrml_node.SetAndObserveStorageNodeID(None)
         else:
-            if mrml_type is 'vtkMRMLModelNode':
+            if mrml_type.GetClassName() is 'vtkMRMLModelNode':
                 mrml_node.CreateDefaultDisplayNodes()
 
         if transform is not None:
@@ -96,7 +96,7 @@ class MRMLUtility(object):
     @staticmethod
     def saveMRMLNode(node, case_dir):
         if slicer.util.getNode(node.GetName()):
-            file_name = node.GetName().split("_")[0]
+            file_name = node.GetName()
             class_name = node.GetClassName()
             if class_name == 'vtkMRMLScalarVolumeNode' or class_name == 'vtkMRMLLabelMapVolumeNode':
                 file_name += '.nrrd'

--- a/Modules/Scripted/ShapeAnalysisToolBox/DataImporter.py
+++ b/Modules/Scripted/ShapeAnalysisToolBox/DataImporter.py
@@ -49,7 +49,7 @@ class DataImporterLogic(ScriptedLoadableModuleLogic):
 
   def createSingleDisplaySegmentModelNode(self):
     if MRMLUtility.isMRMLNodeEmpty(self.singleDisplayedSegmentation, 'vtkMRMLModelNode'):
-      self.singleDisplayedSegmentation = MRMLUtility.createNewMRMLNode('CurrentSegmentation', 'vtkMRMLModelNode')
+      self.singleDisplayedSegmentation = MRMLUtility.createNewMRMLNode('CurrentSegmentation', slicer.vtkMRMLModelNode())
 
   #
   # Reset all the data for data import
@@ -88,7 +88,7 @@ class DataImporterLogic(ScriptedLoadableModuleLogic):
 
       # Create segmentation representations.
       self.segmentationDict[fileName] = MRMLUtility.createNewMRMLNode(fileName + '_allSegments',
-                                                                      'vtkMRMLSegmentationNode')
+                                                                      slicer.vtkMRMLSegmentationNode())
       slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(self.testCaseDict[fileName],
                                                                             self.segmentationDict[fileName])
       t = self.segmentationDict[fileName].CreateClosedSurfaceRepresentation()


### PR DESCRIPTION
The issue was mostly due to a naming conflict with the directory CommonUtilities that SPHARM-PDM also have and erase during the packaging of SlicerSALT. The solution was to make the two codes in the utility file similar. 