### PR TITLE
ENH: Adding of Shape Regression extension

### DIFF
--- a/CMake/Superbuild/CMakeLists.txt
+++ b/CMake/Superbuild/CMakeLists.txt
@@ -52,10 +52,16 @@ ExternalProject_Add_Source(MeshToLabelMap
   GIT_TAG "9e2e199b99396c570f5f26c0ccfd5e149f6b9d34"
   SOURCE_DIR_VAR MeshToLabelMap_SOURCE_DIR
   )
-list(APPEND Slicer_REMOTE_DEPENDENCIES MeshToLabelMap)
+ExternalProject_Add_Source(Sequences
+  GIT_REPOSITORY ${git_protocol}://github.com/SlicerRt/Sequences.git
+  GIT_TAG "c867c678dfbed002d843884b10e6e978f9e78a0e"
+  SOURCE_DIR_VAR Sequences_SOURCE_DIR
+  )
+list(APPEND Slicer_REMOTE_DEPENDENCIES MeshToLabelMap Sequences)
 
 set(Slicer_REMOTE_SOURCE_DIRS
   ${MeshToLabelMap_SOURCE_DIR}
+  ${Sequences_SOURCE_DIR}
   )
 set_property(GLOBAL APPEND PROPERTY ${APPLICATION_NAME}_MODULES ${Slicer_REMOTE_SOURCE_DIRS})
 

--- a/CMake/Superbuild/External_ShapeRegressionExtension.cmake
+++ b/CMake/Superbuild/External_ShapeRegressionExtension.cmake
@@ -1,0 +1,74 @@
+#============================================================================
+#
+# Copyright (c) Kitware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#============================================================================
+#
+# External project for the project.
+#
+
+set(proj ShapeRegressionExtension)
+
+# Set dependency list
+set(${proj}_DEPENDENCIES Slicer)
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED ${proj}_DIR AND NOT EXISTS ${${proj}_DIR})
+  message(FATAL_ERROR "${proj}_DIR variable is defined but corresponds to non-existing directory")
+endif()
+
+if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+
+  if(NOT DEFINED git_protocol)
+    set(git_protocol "git")
+  endif()
+
+  set(config ${CMAKE_BUILD_TYPE})
+  if(DEFINED CMAKE_CONFIGURATION_TYPES)
+    set(config ${CMAKE_CFG_INTDIR})
+  endif()
+
+  set(${proj}_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(${proj}_PACKAGE_DIR ${${proj}_DIR}/${proj}-build)
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${git_protocol}://github.com/laurapascal/ShapeRegressionExtension.git"
+    GIT_TAG "a78faad0806c078eeba65a22600110d22c8823ad"
+    SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
+    BINARY_DIR ${${proj}_DIR}
+    INSTALL_COMMAND ${CMAKE_COMMAND} --build ${${proj}_PACKAGE_DIR} --config ${config} --target package
+    CMAKE_CACHE_ARGS
+      -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      -DSlicer_DIR:PATH=${Slicer_DIR}/Slicer-build
+      -D${proj}_BUILD_SLICER_EXTENSION:BOOL=ON
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+
+  list(APPEND ${APPLICATION_NAME}_EXTENSION_CPACK_PACKAGE_DIRS
+    ${${proj}_PACKAGE_DIR}/_CPack_Packages
+    )
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
+endif()

--- a/CMake/Superbuild/External_Slicer.cmake
+++ b/CMake/Superbuild/External_Slicer.cmake
@@ -58,7 +58,6 @@ if(NOT DEFINED ${proj}_DIR)
     Endoscopy
     LabelStatistics
     PerformanceTests
-    SampleData
     SurfaceToolbox
     VectorToScalarVolume
     )
@@ -90,6 +89,7 @@ if(NOT DEFINED ${proj}_DIR)
     PETStandardUptakeValueComputation
     ProbeVolumeWithModel
     RobustStatisticsSegmenter
+    SampleData
     SimpleRegionGrowingSegmentation
     SubtractScalarVolumes
     ThresholdScalarVolume

--- a/CMake/Superbuild/External_SlicerPackageExtensions.cmake
+++ b/CMake/Superbuild/External_SlicerPackageExtensions.cmake
@@ -31,6 +31,7 @@ set(proj SlicerPackageExtensions)
 set(${proj}_EXTENSIONS
   SPHARM-PDM
   ShapePopulationViewer
+  ShapeRegressionExtension
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
ENH: Adding of Shape Regression extension containing two modules:

- RegressionComputation: Computation of time-regressed shapes in a collection of 3D shape inputs associated to a linear variable.
This module uses shape4D CLI: https://github.com/laurapascal/shape4D

- RegressionVisualization:
* Plot the time-regressed shape volume according to the linear variable
* Visualize the sequence of the time-regressed shapes generated
This module uses Sequences and SampleData Extension