### PR TITLE
ENH: enable surface toolbox and model merge modules in slicer

### DIFF
--- a/CMake/Superbuild/External_Slicer.cmake
+++ b/CMake/Superbuild/External_Slicer.cmake
@@ -58,7 +58,7 @@ if(NOT DEFINED ${proj}_DIR)
     Endoscopy
     LabelStatistics
     PerformanceTests
-    SurfaceToolbox
+    #SurfaceToolbox
     VectorToScalarVolume
     )
   set(Slicer_CLIMODULES_DISABLED
@@ -94,7 +94,7 @@ if(NOT DEFINED ${proj}_DIR)
     SubtractScalarVolumes
     ThresholdScalarVolume
     VotingBinaryHoleFillingImageFilter
-    MergeModels
+    #MergeModels
     #ModelMaker
     ResampleDTIVolume
     # ResampleScalarVectorDWIVolume # Needed by 'CropVolume' module


### PR DESCRIPTION
Adding the surface toolbox and the merge model modules in Slicer. When packaged into SlicerSALT these will be visible under Surface Models section. Surface toolbox description can be found [here](https://www.slicer.org/wiki/Documentation/Nightly/Modules/SurfaceToolbox) and for Merge Models can be found [here](https://www.slicer.org/wiki/Documentation/Nightly/Modules/MergeModels).