### PR TITLE
ENH: Update ShapeRegressionExtension

### DIFF
--- a/SuperBuild/External_ShapeRegressionExtension.cmake
+++ b/SuperBuild/External_ShapeRegressionExtension.cmake
@@ -54,7 +54,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/KitwareMedical/ShapeRegressionExtension.git"
-    GIT_TAG "dbfbae5e1478a502ade903910862959aa32a7be9"
+    GIT_TAG "c550e279da633906344dd7b4ae86425e536ca853" # 2018-08-31
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${${proj}_DIR}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build ${${proj}_PACKAGE_DIR} --config ${config} --target package


### PR DESCRIPTION
Date: 2018-08-31

https://github.com/KitwareMedical/ShapeRegressionExtension/tree/c550e279da633906344dd7b4ae86425e536ca853

`git shortlog --no-merges dbfbae5e1478a502ade903910862959aa..c550e279da63390634`

```
James Fishbaugh (12):
      Added correct affiliation for James Fishbaugh.
      Time Parameters section: changed t0 and tn to doubles and minor changes to layout.
      ENH: Time Parameters section: changed t0 and tn to doubles and minor changes to layout.
      ENH: Added default values for shape kernel width and deformation kernel width, computed as 50% of the smallest dimension of the axis-aligned bounding box around each shape.
      ENH: Deformation Parameters section: Kernel width changed to double, regularity weight set with a default value of 0.01, and some minor formatting fixes.
      ENH: Output Parameters section: added default values.
      ENH: Optional Parameters section: modified default values.
      ENH: Extract numeric suffix from filename to auto populate time point for each shape. If no suffix is found, time point is set as 0.
      ENH: Initialize a viable rootname when the input directory is changed, by searching for *final_time*.vtk.
      ENH: Added auto population of rootname and input shapes CSV when input directory is selected.
      STYLE: Fixed typo for output CSV file (from CVS).
      ENH: Made changes to the UI elements for the Regression Volume Plot.

Pablo Hernandez-Cerdan (8):
      STYLE: Remove unused, strip whitespaces RegVis
      COMP: Use slicer.util instead of MRMLUtility
      BUG: Fix loadModel call
      BUG: Update name of plot class
      COMP: Provide minimum compatible slicer version.
      ENH: Auto-orient normals in RegressionVisualization
      ENH: RegComputation compatible with qt4 and qt5
      STYLE: Simplify test comparison
```