### PR TITLE
COMP: Update Sequences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,8 @@ set(extension_name "Sequences")
 set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
-  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/SlicerRt/Sequences.git
-  GIT_TAG        a4b32e822505373d34f250123421ac9485f3947c
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/phcerdan/Sequences.git
+  GIT_TAG        origin/disable_sampledata # Temporary workaround, see @SlicerSALT#50
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION
This includes a workaround to avoid the python error
about missing the module SampleData, which SequencesSampleData depends
on.
The branch included just disables SequencesSample. More info #50

`git shortlog --no-merges a4b32e822505373d34f250123..`

```
Pablo Hernandez-Cerdan (1):
      COMP: Disable SequenceSampleData

Thomas Vaughan (1):
      BUG: Fix unused variable warnings in module widgets
```