### PR TITLE
COMP: Update GROUPS extension to fix build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,8 +195,8 @@ set(extension_name "GROUPS")
 set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
-  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/NIRALUser/GROUPS
-  GIT_TAG        bfb31b79beaf0a728c6b66a85bf88aa68a345892
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/jcfr/GROUPS
+  GIT_TAG        ba967ad7d38d12bf82d536dc6916201e13670832
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION
Fixes #78

List of changes:

```
$ git shortlog bfb31b7..ba967ad --no-merges
Jean-Christophe Fillion-Robin (1):
      cmake: Fix bundling of the extension adding dependency to RigidAligment and SurfRemesh
```