### PR TITLE
BUG: Update Groups, solve qt5 comp errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/jcfr/GROUPS
-  GIT_TAG        a8281d7e3f8d9fc5f4b6d321921eeeb678c176e0
+  GIT_TAG        47ae1842394984576be759880ffc11d13d4cfbcd
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION
`git shortlog --no-merges a8281d7e3f..47ae1842`

```
Pablo Hernandez-Cerdan (3):
      STYLE: Apply dos2unix to GroupWiseRegistrationModule
      STYLE: Add .gitignore
      BUG: Fix header resize to be compatible with qt5
```