### PR TITLE
BUG: Fix window menu shortcut name for installation of SlicerSALT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/jcfr/Slicer
-    GIT_TAG        b6764a60f81d9e087b69d67267425c9d43b2805f # slicersalt-1.0-2018-09-13-8c19c293c
+    GIT_TAG        109d50f883726d283c48406b196b339705558d34 # slicersalt-4.9-2018-09-13-8c19c293c
     GIT_PROGRESS   1
     )
 else()


### PR DESCRIPTION
Fixes #89

List of changes:

$ git shortlog b6764a60f..109d50f88 --no-merges
jcfr (1):
      [backport] BUG: Fix start menu shortcut of installed custom Slicer application