### PR TITLE
BUG: Update SPHARM, fix compatibility with qt5

### DIFF
--- a/SuperBuild/External_SPHARM-PDM.cmake
+++ b/SuperBuild/External_SPHARM-PDM.cmake
@@ -53,8 +53,8 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   set(${proj}_PACKAGE_DIR ${${proj}_DIR}/${proj}-build)
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/NIRALUser/SPHARM-PDM.git"
-    GIT_TAG "08eaaed1f133c3c697ea1e24f37941699b5c4650"
+    GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/jcfr/SPHARM-PDM.git"
+    GIT_TAG "808d62926dfd7e6ddefd8c902c4ba3dc10df3e87"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${${proj}_DIR}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build ${${proj}_PACKAGE_DIR} --config ${config} --target package


### PR DESCRIPTION
`git shortlog --no-merges  08eaaed1f13..808d62926dfd`

```
Pablo Hernandez-Cerdan (1):
      BUG: Fix header resize to be compatible with qt4 and qt5
```