### PR TITLE
ENH: Update ShapeRegressionExtension

### DIFF
--- a/SuperBuild/External_ShapeRegressionExtension.cmake
+++ b/SuperBuild/External_ShapeRegressionExtension.cmake
@@ -54,7 +54,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/KitwareMedical/ShapeRegressionExtension.git"
-    GIT_TAG "c550e279da633906344dd7b4ae86425e536ca853" # 2018-08-31
+    GIT_TAG "983564f9cdd51cfcb3e35ab26e15d7db314b7d54 " # 2018-09-13 (master)
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${${proj}_DIR}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build ${${proj}_PACKAGE_DIR} --config ${config} --target package


### PR DESCRIPTION
`git shortlog --no-merges  c550e279..983564f9cdd`

```
James Fishbaugh (7):
      BUG: Changed test to use gradient descent as default optimization method.
      STYLE: Changed the plot style and colors of the volume plot.
      BUG: Changed the plot type to scatter, which appears to fix a bug where x-axis values were not plotting correctly.
      STYLE: Time point range spinboxes were changed to fill horizontal space.
      ENH: Updated the range of the weights for each shape observation.
      BUG: RegressionModel dictionary assumed there would be a key of 0, which would cause problems loading sequences with a 0 suffix. This has been fixed.
      ENH: Compute regression volume before orienting normals to avoid altering the volume of the underlying data.
```