### PR TITLE
cmake: Update GROUPS and SPHARM-PDM to use the same LAPACK external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/jcfr/Slicer
-    GIT_TAG        92726ca29f4a8ba63dd1d0a9426309c30bb5d3fc # slicersalt-4.9-2018-09-13-8c19c293c
+    GIT_TAG        e08d28f2e8ced063b55c541142be86e10a94f218 # slicersalt-4.9-2018-09-13-8c19c293c
     GIT_PROGRESS   1
     )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/SRep")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/KitwareMedical/SlicerSkeletalRepresentation
-  GIT_TAG        dfb8cab5cf9a2422ac69fd0b37f82f88e8c969dd # 2018-09-07 Rename
+  GIT_TAG        f163fcb264b16af0b8f2a8348f9dd959b14cca23 # fix-window-build-error
   GIT_PROGRESS   1
   QUIET
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/jcfr/Slicer
-    GIT_TAG        109d50f883726d283c48406b196b339705558d34 # slicersalt-4.9-2018-09-13-8c19c293c
+    GIT_TAG        92726ca29f4a8ba63dd1d0a9426309c30bb5d3fc # slicersalt-4.9-2018-09-13-8c19c293c
     GIT_PROGRESS   1
     )
 else()
@@ -205,7 +205,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/jcfr/GROUPS
-  GIT_TAG        c2aeef986225d6f0b153d212dc94270757746fab
+  GIT_TAG        eccc12094d2a9abd756a1b76450d9bd5af0772f6
   GIT_PROGRESS   1
   QUIET
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/jcfr/GROUPS
-  GIT_TAG        47ae1842394984576be759880ffc11d13d4cfbcd
+  GIT_TAG        c2aeef986225d6f0b153d212dc94270757746fab
   GIT_PROGRESS   1
   QUIET
   )

--- a/SuperBuild/External_SPHARM-PDM.cmake
+++ b/SuperBuild/External_SPHARM-PDM.cmake
@@ -54,7 +54,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/jcfr/SPHARM-PDM.git"
-    GIT_TAG "808d62926dfd7e6ddefd8c902c4ba3dc10df3e87"
+    GIT_TAG "d3f8b242a467be8616ccc8d611a734d931ef49a6"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${${proj}_DIR}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build ${${proj}_PACKAGE_DIR} --config ${config} --target package

--- a/SuperBuild/External_SPHARM-PDM.cmake
+++ b/SuperBuild/External_SPHARM-PDM.cmake
@@ -54,7 +54,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/jcfr/SPHARM-PDM.git"
-    GIT_TAG "d3f8b242a467be8616ccc8d611a734d931ef49a6"
+    GIT_TAG "c6683a7a80ea21b2a103445ccdf8dd99ce777176" # slicersalt-2018-09-11-08eaaed1f
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${${proj}_DIR}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build ${${proj}_PACKAGE_DIR} --config ${config} --target package


### PR DESCRIPTION
List of GROUPS changes:

$ git shortlog 47ae184..c2aeef9 --no-merges
Jean-Christophe Fillion-Robin (1):
      cmake: Update LAPACK external project to always log configuration and build

List of SPHARM-PDM changes:

$ git shortlog 808d629..d3f8b24 --no-merges
Jean-Christophe Fillion-Robin (1):
      cmake: Update LAPACK external project to fix macOS and Linux build error