### PR TITLE
COMP: Update ShapePopulationViewer to fix windows configuration error

### DIFF
--- a/SuperBuild/External_ShapePopulationViewer.cmake
+++ b/SuperBuild/External_ShapePopulationViewer.cmake
@@ -54,7 +54,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/NIRALUser/ShapePopulationViewer.git"
-    GIT_TAG "deb14cdcaef475d5e545c94600d3bd7b02b6fe07"
+    GIT_TAG "724374ca71ce58ec12bbe179debee93fb97ec118"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${${proj}_DIR}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build ${${proj}_PACKAGE_DIR} --config ${config} --target package


### PR DESCRIPTION
List of changes:

$ git shortlog deb14cdca..724374c --no-merges
Jean-Christophe Fillion-Robin (3):
      cmake: Fix windows configuration failure
      cmake: Remove support for building against ITKv3
      cmake: Remove obsolete code