### PR TITLE
ENH: Update to Slicer 4.11-2018-11-08-94fb4a634

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/jcfr/Slicer
-    GIT_TAG        cd7d51ce9b613bdf966281d9a841017473ec0c07 # slicersalt-4.9-2018-09-13-8c19c293c
+    GIT_TAG        9e3e45ae9ae437f95bd4a18d1550aeeb24895b95 # slicersalt-4.11-2018-11-08-94fb4a634
     GIT_PROGRESS   1
     )
 else()


### PR DESCRIPTION
List of changes:

$ git shortlog cd7d51ce9b..9e3e45ae9ae --no-merges
Jared Vicory (2):
      ENH: Update NumPy to 1.15.1
      ENH: Patch NumPy to allow building SciPy using flang

Jean-Christophe Fillion-Robin (3):
      [Backport Slicer/Slicer#1022] COMP: Support packaging of extension from within Slicer custom application
      [Backport Slicer/Slicer#1022] COMP: Support packaging of libraries outside of Slicer or extension build tree
      [Backport Slicer/Slicer#1022] COMP: Support non-superbuild extension that define CPACK_INSTALL_CMAKE_PROJECTS

cpinter (8):
      COMP: Fix build on Qt4/VTK7
      BUG: Fixed Pick3D initialization in displayable managers
      BUG: Fix default display and storage node creation
      BUG: Fix 3D picking in displayable managers
      ENH: Consider default display node on SH visibility change
      STYLE: Fix typos in vtkMRMLPlotSeriesNode
      ENH: Add option to get directly referenced nodes
      ENH: Allow observing color name change

ihnorton (1):
      ENH: add CompressionLevel to storage node, use in NRRDWriter

jcfr (69):
      COMP: Fix build when extension manager support is disabled
      BUG: Fix start menu shortcut of installed custom Slicer application
      STYLE: Add comments to SlicerExtensionCPack and SlicerCPack modules
      ENH: Support fix-up of shared third-party libraries installed by extension.
      COMP: Exclude system library when updating EXTENSION_BUNDLE_FIXUP_LIBRARY_DIRECTORIES
      BUG: Fix version displayed in Slicer custom application
      ENH: Update SlicerExecutionModel
      STYLE: Simplify SlicerExecutionModel external project
      COMP: Fix typo in SlicerExtensionCPackBundleFixup
      BUG: Update VTK to include OpenGL2 backend and OpenVR fixes
      BUG: Update VTK and remove revert of change of VTK version from 9.0.0 to 8.2.0
      BUG: Update VTK to also revert update of legacy check
      COMP: Update FreeSurfer reader to support updated vtkDataReader API
      ENH: Update VTK to support improve SlicerVR and SlicerAR extensions
      COMP: CLI/ResampleDTIVolume: Fix warning catching exception by value
      BUG: Ensure Qt5 Designer library is packaged. Fix #4607
      BUG: Allow vertical resize of extension manager. Fix #4613
      COMP: qSlicerApplication: Fix Qt4 build error
      COMP: qSlicerWebWidget: Fix Qt4 build error excluding qSlicerWebEngineView
      COMP: qSlicerApplicationHelper: Fix Qt4 build error adding missing includes
      COMP: Fix Qt4 unused variable warnings
      BUG: ExtensionsManager: Fix opening of external links. Fix #4552
      COMP: qSlicerWebWidget: Fix unused variable warning
      COMP: Fix build updating URLs used to download Swig archives
      BUG: ExtensionsManager: Fix back button in Manage tab. Fix #4551
      BUG: ExtensionsManager: Associate QObjects with window and fix button rendering
      BUG: Update VTK: Backport improvements and revert commit to fix issue 4628
      ENH: Update CTKAppLauncher: Add support for interactive process
      ENH: Disable TCL Bridge by default  See #4625
      BUG: Update VTK to effectively include fix for #4628
      COMP: Update c++ classes to support building against VTK >= 9 and VTK >= 8.2
      COMP: Update VTK to include version change from 9.0 to 8.2. Fixes #4623
      BUG: qSlicerXcedeCatalogReader: Fix reading of description in importVolumeNode
      STYLE: Fix spelling in parameters, ivars, comments, labels and messages
      ENH: Add runCodespell maintenance script
      COMP: Update CTKAppLauncherLib to fix windows link error. Fix #4631
      ENH: qSlicerWebWidget: Add support for handling external URLs
      STYLE: qSlicerWebWidgetPrivate: Introduce initializeWebEngineProfile()
      BUG: qSlicerWebWidget: Share default profile between all widget instances
      BUG: Update DataStore module to support Qt5/WebEngine. Fixes issue 4567
      COMP: Fix DataStore windows link error exporting qSlicerWebWidgetPrivate symbols
      STYLE: Update DataStore module
      COMP: Ensure vtkSlicerVersionConfigure is available for MRML libraries
      BUG: Update CTK to fix ctkDoubleSpinBox sizeHint. Fixes issue 4633
      ENH: Rename VTK external project removing version number
      ENH: Rename ITK external project removing version number
      BUG: Fix WebEngine errors when extensions manager is opened with linux package
      BUG: Fix vtk python package import in windows package. Fix issue 4636
      BUG: Disable extension auto-update attempt. Fix issue 4641
      STYLE: qSlicerRestoreExtensions: Introduce ItemDataRole enum
      STYLE: SlicerExtensionsRestoreWidget: Simplify relying on Qt implicit sharing
      ENH: Improve Extensions Manager restore tab user experience
      BUG: Update VTK to fix support for clipped voxel intensity in VR. Fix 4513
      BUG: Improve user experience keeping DataProbe height consistent
      ENH: Slicer 4.10.0
      ENH: Begin 4.11.0 development
      BUG: Ensure configured CDash project name is used to build stable extensions
      ENH: ExtensionsBuildSystem: Support disabling extension build CTest step
      BUG: Fix Slicer wiki update script
      BUG: Fix stable release version ensuring release type is passed by driver script
      BUG: Fix typo in qSlicerVolumeRenderingModuleWidget
      ENH: Update Slicer.crt CA bundle
      BUG: Fix setting of next version in Slicer wiki update script
      COMP: Update QtWebEngineProcess.app macOS install rule to fix code signing
      COMP: Fix -Wconversion-null warning in vtkMRMLNodeTest1
      COMP: Fix -Wunused-parameter warning in FindPickedDisplayNodeFromMesh
      COMP: Future proof vnl_math function usage.
      COMP: Remove unneeded reference to vcl_compiler.h
      BUG: Update SimpleFilters remote to fix runtime warnings

lassoan (42):
      BUG: Fixed return value passing from scripted file dialog execDialog
      ENH: Make segment editor brush appear in yellow instead of white
      BUG: Fixed opacity of ROI widget with depth peeling
      BUG: Fix passing module paths containing single quote
      COMP: Fixed build error with older Qt versions
      BUG: Fixed hiding of node selectors in qMRMLSegmentEditorWidget
      ENH: Updated to latest CTK
      ENH: Add pause render functions to qMRMLLayoutManager and qSlicerApplication
      BUG: Fix qSlicerScriptedLoadableModuleTest and qSlicerScriptedLoadableModuleWidgetTest
      BUG: Fix vtkMRMLThreeDReformatDisplayableManagerTest1
      BUG: Fix 3 view widget tests
      BUG: Fix py_ThresholdThreadingTest
      BUG: Fixed py_nomainwindow_SlicerOptionDisableSettingsTest on Windows
      ENH: Allow saving empty segmentation node
      BUG: Attempt to fix qSlicerReformatModuleWidgetGenericTest
      BUG: Fixed mrb file saving
      ENH: Added direct color mapping option to Models module
      ENH: Allow frames-per-second specification as alternative to video length.
      ENH: Add tooltip to plot series widget
      ENH: Update MultiVolumeImporter
      ENH: Report insufficient OpenGL support instead of crashing
      BUG: Fixed Windows remote desktop reconnection on OpenGL version check
      COMP: Fixed non-Windows build errors
      BUG: Disable rendering capability check on Linux and Mac
      BUG: Fixed crash at application exit
      ENH: Added centered label display to color node scalar bar
      ENH: Enable VR smooth clipping
      BUG: Fix scalar range in colormap exported from segmentation
      ENH: Add CT-Air volume rendering preset
      ENH: Set default attribute value for Scene::Clear(bool)
      BUG: Fixed logging in SampleData
      BUG: Fixed update of imported nodes in subject hierarchy
      BUG: Fix Segment Editor to work with multi-component master volume
      ENH: Improved VectorToScalarVolume usability
      BUG: Fix FreeSurfer surface reader
      STYLE: Removed non-ASCII characters from some comment lines
      ENH: Add vtkMRMLStreamingVolumeNode for compressed video
      BUG: Fix failing vtkMRMLStreamingVolumeNode test and memory leak
      ENH: Add methods to access view controllers in plot and table widgets
      BUG: Update crosshair RAS position when slice is moved
      COMP: Fix warnings from missing VTK_OVERRIDE in vtkRawRGBVolumeCodec
      BUG: Prevent XCode install request popup on Mac

pieper (4):
      BUG: try to fix for #4252
      ENH: vtkAddons for general purpose OpenGL shader programming
      BUG: update LandmarkRegistration hash, fix for #4632
      COMP: fix macOS mojave build errors