### PR TITLE
BUG: Fix ShapePopulationViewer crash and improve UX updating external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/jcfr/Slicer
-    GIT_TAG        4e8b8ddc5de713fdfb7b2fb15c472a4b31c19b84 # slicersalt-4.11-2018-11-12-e93ec804c
+    GIT_TAG        57f3aac8d348a6f10a03da1a85a3decb4c216b50 # slicersalt-4.11-2018-11-16-51dffa182
     GIT_PROGRESS   1
     )
 else()
@@ -248,7 +248,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/jcfr/ShapePopulationViewer
-  GIT_TAG        e7ea3d7a4a436a12bda56bbacb00ed324e3d04e3 # reusable-widget
+  GIT_TAG        a422dbfbeea4f9ed258f679cd874b20f215a9d50 # slicersalt-2018-09-16-6de7a0409
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION

Slicer and ShapePopulationViewer external projects are updated.

Key changes are the following:
* Add support for explicitly loading vtkMRMLModelNode from Slicer scene
* Automatically load model node added to the Slicer scene. This means
  drag and drop of models is supported.
* Support export to PDF, SVG, ... in Slicer
* Improve Slicer module widget layout


List of ShapePopulationViewer changes:

```
$ git shortlog e7ea3d7a4..a422dbf --no-merges
Jean-Christophe Fillion-Robin (15):
      COMP: Ensure CMAKE_CXX_STANDARD is set doing clean build against Slicer 4.10
      ENH: Refactor "CreateWidgets()" function to accept a list of files
      STYLE: Add ShapePopulationViewerConfig.h.in header
      STYLE: Simplify removing unneeded ShapePopulationData::GetFilePath() function
      BUG: Fix crash when loading more than 3 models simultaneously
      BUG: Fix crash when loading model after deleting previously loaded ones
      ENH: Add support for explicitly loading vtkMRMLModelNode from Slicer scene
      ENH: Automatically load model node added to the Slicer scene
      ENH: Support export in Slicer if feature is available
      ENH: Improve Slicer module widget layout
      ENH: Ensure tests are executed with expected environment
      BUG: Avoid redundant event ensuring "min range update" is consistent
      STYLE: Refactor code introducing ShapePopulationColorMapIO
      ENH: Build Slicer module without GPL code from "gradientWidgetQT"
      BUG: Ensure add/remove arrow buttons are visible in standalone CLI
```

List of Slicer changes:

```
$ git shortlog 4e8b8ddc..57f3aac8 --no-merges
Jared Vicory (2):
      ENH: Update NumPy to 1.15.1
      ENH: Patch NumPy to allow building SciPy using flang

Jean-Christophe Fillion-Robin (3):
      [Backport Slicer/Slicer#1022] COMP: Support packaging of extension from within Slicer custom application
      [Backport Slicer/Slicer#1022] COMP: Support packaging of libraries outside of Slicer or extension build tree
      [Backport Slicer/Slicer#1022] COMP: Support non-superbuild extension that define CPACK_INSTALL_CMAKE_PROJECTS

jcfr (4):
      STYLE: Update vtkMRMLColorLogic::AddDefaultColorNodes docstring
      ENH: Update CTK to include ctkVTKScalarsToColorsWidget improvements
      COMP: Fix ITK external project to require correct ITK system version
      BUG: Update DCMTK to fix DICOM TR support for along-track measurements

lassoan (8):
      BUG: Fixed volume rendering ROI reset
      BUG: Fixed closed surface to labelmap conversion in segmentation
      ENH: Allow loading .obj file as segmentation
      ENH: Add vtkMRMLStorageNode CompressionParameter and presets
      BUG: Update SimpleFilters remote to fix errors on close
      ENH: Change default colormap for model scalars and transforms
      ENH: Make custom application version more accessible
      BUG: Fixed multiple loading of DICOM files
```