### PR TITLE
COMP: Update GROUPS to fix RigidAlignement unix build error due to invalid array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,8 +212,8 @@ set(extension_name "GROUPS")
 set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
-  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/vicory/${extension_name}
-  GIT_TAG        cba8671e95d379bc2ad2389fc1bb63e7d4cda76f # slicersalt-2018-11-16-15c897e
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/jcfr/${extension_name}
+  GIT_TAG        0ea64cf36c72385405b2dde0212ca5e222a07cea # slicersalt-2018-11-16-15c897e
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION
This PR integrates https://github.com/jcfr/RigidAlignment/commit/dacd7ca503e3cf7a4a3301e5901e756acc978cca

It fixes the following build error introduced by NIRALUser/RigidAlignment@7f0ac80(BUG: Fix Windows crash on array allocation):

```
  In file included from /usr/include/c++/5/vector:62:0,
                   from ./RigidAlignmentCLP.h:8,
                   from /path/to/SlicerSALT/RigidAlignment/RigidAlignment.cxx:11:
  /usr/include/c++/5/bits/stl_construct.h: In instantiation of ‘void std::_Destroy(_Tp*) [with _Tp = std::__cxx11::basic_string<char> [250]]’:
  /usr/include/c++/5/bits/stl_construct.h:103:19:   required from ‘static void std::_Destroy_aux<<anonymous> >::__destroy(_ForwardIterator, _ForwardIterator) [with _ForwardIterator = std::__cxx11::basic_string<char> (*)[250]; bool <anonymous> = false]’
  /usr/include/c++/5/bits/stl_construct.h:127:11:   required from ‘void std::_Destroy(_ForwardIterator, _ForwardIterator) [with _ForwardIterator = std::__cxx11::basic_string<char> (*)[250]]’
  /usr/include/c++/5/bits/stl_construct.h:151:15:   required from ‘void std::_Destroy(_ForwardIterator, _ForwardIterator, std::allocator<_T2>&) [with _ForwardIterator = std::__cxx11::basic_string<char> (*)[250]; _Tp = std::__cxx11::basic_string<char> [250]]’
  /usr/include/c++/5/bits/stl_vector.h:424:22:   required from ‘std::vector<_Tp, _Alloc>::~vector() [with _Tp = std::__cxx11::basic_string<char> [250]; _Alloc = std::allocator<std::__cxx11::basic_string<char> [250]>]’
  /path/to/SlicerSALT/RigidAlignment/RigidAlignment.cxx:239:54:   required from here
  /usr/include/c++/5/bits/stl_construct.h:93:7: error: request for member ‘~std::__cxx11::basic_string<char> [250]’ in ‘* __pointer’, which is of non-class type ‘std::__cxx11::basic_string<char> [250]’
       { __pointer->~_Tp(); }
         ^
  ninja: build stopped: subcommand failed.
  FAILED: slicersources-build/RigidAlignment-prefix/src/RigidAlignment-stamp/RigidAlignment-build
```

List of changes:

```
$ git shortlog cba8671..1237c29 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Update RigidAlignement to fix unix build error due to invalid array
```