### PR TITLE
BUG: Update Slicer to fix DataImporter error on application exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/slicersalt/Slicer
-    GIT_TAG        9cb1e810754d6c2e59e6658e0ae8467245dcb3d2 # slicersalt-4.11-2019-04-22-eeb2d75e8
+    GIT_TAG        e71081e8c4423902ed867d5b741ec6d7e4077bce # slicersalt-4.11-2019-04-24-62ed8d6d4
     GIT_PROGRESS   1
     )
 else()

--- a/Modules/Scripted/ShapeAnalysisToolBox/DataImporter.py
+++ b/Modules/Scripted/ShapeAnalysisToolBox/DataImporter.py
@@ -578,9 +578,6 @@ class DataImporterWidget(ScriptedLoadableModuleWidget):
     self.resetSegmentsTable()
     self.resetGlobalVariables()
 
-  def __del__(self):
-    self.cleanup()
-
   #
   # Functions to recover the widget in the .ui file
   #


### PR DESCRIPTION
List of changes:

$ git shortlog 9cb1e8107..e71081e8c --no-merges
Jean-Christophe Fillion-Robin (3):
      [Backport Slicer/Slicer#1022] COMP: Support packaging of extension from within Slicer custom application
      [Backport Slicer/Slicer#1022] COMP: Support packaging of libraries outside of Slicer or extension build tree
      [Backport Slicer/Slicer#1022] COMP: Support non-superbuild extension that define CPACK_INSTALL_CMAKE_PROJECTS

jcfr (5):
      ENH: Install pip independently of extension manager support
      BUG: Update CTK to include DICOM display fields and python manager fixes
      COMP: Update CTK including expected PythonQt version
      BUG: Do not report error when logging message in ScriptedLoadableModuleWidget.cleanup
      BUG: Ensure logged messages are handled during application destruction

lassoan (2):
      BUG: Fixed editor effect: Fill between slices
      ENH: Enable depth peeling in 3D views by default