### PR TITLE
ENH: Update SPHARM-PDM to support Python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        d64286a7657fb81a7d656270732fff3a508a4be3 # slicersalt-2018-09-17-a483d8106
+  GIT_TAG        d21fccf790d79d61f4ada1efb474684477a6310d # slicersalt-2019-08-08-4baa99c10
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION
Updates SPHARM-PDM to fix python 3-related errors

Fixes one of the issues identified in #167 