### PR TITLE
ENH: Update Slicer to integrate updated SurfaceToolbox module. See #182

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/slicersalt/Slicer
-    GIT_TAG        344ced6b1d442275a04eae41029e62502c7a3f23 # slicersalt-4.11-2019-07-05-344ced6b1
+    GIT_TAG        933a0785f544d2ee862306c4d6932c7aa0c80eb1 # slicersalt-4.11-2019-09-04-933a0785f
     GIT_PROGRESS   1
     )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/slicersalt/Slicer
-    GIT_TAG        933a0785f544d2ee862306c4d6932c7aa0c80eb1 # slicersalt-4.11-2019-09-04-933a0785f
+    GIT_TAG        ea8d3e3166730dc788cd30adadb13fa22e92743b # slicersalt-4.11-2019-09-04-933a0785f
     GIT_PROGRESS   1
     )
 else()


### PR DESCRIPTION
List of changes:

```
$ git shortlog 344ced6b1..933a0785f --no-merges
cpinter (17):
      BUG: Fix setting volume property for multivolume in volume rendering
      BUG: Remove SH harden transform question if changing transform on single item
      BUG: Fix crash when closing application after certain operations in SH
      ENH: Allow handling events by interaction context
      STYLE: Add function for default context name in markups display node
      ENH: Improve volume visibility options in subject hierarchy
      BUG: Fix opacity function for segmentations in subject hierarchy
      ENH: Add reset field of view action for showing volumes in SH
      ENH: Optimize UI of Models and Markups modules
      ENH: Rename overwrite-related masking options in Segment Editor
      ENH: Update CTK hash to include DICOM database fix
      BUG: Fix subject hierarchy cache warnings when loading scene
      ENH: Add SH option to show/hide transform interaction box
      COMP: Remove BTX/ETX from SH plugin headers
      ENH: Update CTK hash to include DICOM db update improvements
      BUG: Fix terminology selector button state when changing context
      BUG: Fix error messages coming from subject hierarchy

jcfr (38):
      STYLE: SampleData: Fix formatting of "Status" message
      BUG: Fix delayDisplay implementation and update docstring
      ENH: Update VTK to support touchscreen and trackpad gestures
      COMP: Fix -Wunused-variable warnings in vtkSlicerMarkupsWidget
      BUG: ReformatLogic: Fix crash checking if scene is associated with the logic
      ENH: ReformatLogic: Support using GetVolumeBounds() without setting a logic scene
      ENH: ReformatLogic: Support use of GetVolumeBounds() as static function
      ENH: ReformatLogic: Support use of SetSliceOrigin/SetSliceNormal as static function
      STYLE: Display discovered executables when fixing up extensions on macOS
      COMP: Ensure CLI libraries are fixed up on macOS
      ENH: Enable Mac touchpad gesture interactions in slice and 3D views
      COMP: Fix -Wunused and -Wsign-compare warnings
      BUG: Update VTK to support image > 2GB when using mask extra segmentation effect
      ENH: Wrap qSlicerSettingsUserInformationPanel::setUserInformation()
      STYLE: Add SurfaceToolBox as a remote module
      COMP: Ensure designer launcher directory exists at configuration time
      COMP: Package JsonCpp if VolumeRendering module is enabled
      BUG: Fix logic issue in qMRMLSegmentsModel
      COMP: Update to ITK5 SpatialObject API
      COMP: Support building loadable module using PUBLIC/PRIVATE/INTERFACE keyword for target_link_libraries
      COMP: Allow compiling OpenSSL and Tbb with all versions of VS2017 and VS2019
      ENH: Support use of SWIG executable in downstream projects (and/or extensions)
      COMP: Update SimpleITK to fix build error related to use of ITK v5.0.1
      COMP: Update BRAINSTools for ITK 5.0.1 compatibility
      BUG: Fix issues with DICOM browser widget
      BUG: Set defaults specific to testing related to DICOM loading
      COMP: Update CTK to fix handling of python libraries
      COMP: Fix CMake 3.15 warning in SlicerLinkerAsNeededFlagCheck project
      COMP: Update CTK to fix regression introduced in r28453
      ENH: Update ITK and use upstream repo
      BUG: Update VTK to fix vtkThinPlateSplineTransform for forward transform of coplanar points
      COMP: Fix vtkMRMLModelStorageNode link error introduced by ITK update
      COMP: Update BRAINSTools and fix itkExceptionObject include error introduced by ITK update
      BUG: Fix tests timeout ensuring dicom database directory is auto created
      BUG: Fix icon name removal in SelectionNode
      BUG: Fix update of the qSlicerMouseModeToolBar
      BUG: Fix python self-tests ensuring dicomBrowser is properly initialized
      ENH: Update SlicerSurfaceToolbox to integrate new filters

lassoan (58):
      ENH: Log application path at startup
      ENH: Added slicer.util functions for getting transform and markups nodes as numpy array
      BUG: Fix delete markup button state updates
      STYLE: Clarified vtkMRMLNode::SetScene documentation
      ENH: Added tests for recently added slicer.util helper functions
      ENH: Set current slice view id during markups interaction
      ENH: Simplify vtkMRMLMarkupsDisplayNode API
      BUG: Fix segment ID copy in vtkSegmentation DeepCopy
      BUG: Fix active markup point display in 3D view
      BUG: Fixed markups curve surface computation for concave surfaces
      BUG: Fixed markup point display in 3D views
      ENH: Store default slice orientation in vtkMRMLSliceNode
      ENH: Update multivolume importer
      BUG: Fix curve surface computation
      BUG: Fix MRMLNodeComboBox_Segmentation is not found in Segment Editor module
      ENH: Add util functions for reading/writing table node columns as numpy array
      ENH: Update qMRMLSegmentsTableView to use model/view architecture
      BUG: Fix clearing of previously selected attribute value in qMRMLNodeAttributeTableView
      ENH: Improve segment list filtering GUI
      ENH: Improve options for segment status in qMRMLSegmentsTableView
      ENH: Improve loading speed when importing segmentation from labelmap
      ENH: Create new view to embed DICOM browser in main widget
      ENH: Change qMRMLSegmentsTableView filter field to ctkSearchBox
      ENH: Hide segment table filter bar by default
      BUG: Fixed slicer.util.updateMarkupControlPointsFromArray
      BUG: Revert "ENH: Create new view to embed DICOM browser in main widget"
      ENH: Simplified conversion between vtkMatrix3x3/vtkMatrix4x4 and numpy array
      BUG: Update CTK to latest master version
      BUG: Fix segment previous/next shortcut and move segment up/down
      BUG: Fix lock window level button state in qSlicerScalarVolumeDisplayWidget
      BUG: Fix crash in Segment table prev/next shortcut
      BUG: Fix segment selection change during undo
      BUG: Fix manual scalar display range setting in Models module
      BUG: Fix show only selected segments option in segment table
      ENH: Improve segment table filtering performance
      ENH: Added separate event for markup centerpoint modified
      BUG: Fixed point insertion into markups curve in 3D view
      BUG: Fixed scalar type mismatch error in Flood fill segment editor effect
      COMP: Fix implicit conversion to string for CMAKE_CXX_MP_NUM_PROCESSORS
      BUG: Ensure current module is exited when restarting application
      BUG: Keep the last placed point when maximum number of markups reached
      BUG: Fix transform switch in subject hierarchy tree
      BUG: Fixed Grow from seeds effect failure to generate output
      ENH: Create new view to embed DICOM browser in main widget
      COMP: Fix ITK5 ModifiedTimeType related build errors on Windows
      BUG: Report error if table node writing fails
      BUG: Fix closed contour markups computation for planar curves
      ENH: Add PointPositionDefinedEvent and PointPositionUndefinedEvent to markups node
      ENH: Add requireSegments property to segment editor effects
      BUG: Fix markups not displayed in new view
      BUG: Fixed markups closed curve area computation
      BUG: Fix SegmentEditorIslandsEffect to make first segment contain the largest island
      ENHL Updated CTK
      ENH: Remove redundancy between qMRMLUtils and ctkVTKWidgetsUtils
      ENH: Added option to add watermark to screen captures
      BUG: Fixed vtkITKImageThresholdCalculator
      ENH: Improve qMRMLSegmentsModel handling of SegmentAdded/SegmentRemoved
      ENH: Remove quick fix recently done in SegmentEditorIslandsEffect

pieper (4):
      BUG: stub out MultiVolume call that prints vtkError
      BUG: avoid crash in volume logic helper
      BUG: more robust sample data download
      BUG: fix single quote escape in CTK SQL DICOM
```