### PR TITLE
BUG: Update Slicer to integrate SlicerSurfaceToolbox fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/slicersalt/Slicer
-    GIT_TAG        ea8d3e3166730dc788cd30adadb13fa22e92743b # slicersalt-4.11-2019-09-04-933a0785f
+    GIT_TAG        0f9e7ae88ba3cc9a7ab01e2f25539e2267911c67 # slicersalt-4.11-2019-09-04-933a0785f
     GIT_PROGRESS   1
     )
 else()


### PR DESCRIPTION
List of changes:

$ git shortlog ea8d3e31..0f9e7ae88 --no-merges
cpinter (1):
      [backport] ENH: Add property for segments table statusColumnVisible

jcfr (4):
      [backport] BUG: Perform performPostModuleDiscoveryTasks only if DICOM is loaded
      [backport] ENH: Update CTK and use latest version of PythonQt
      [backport] BUG: Update SlicerSurfaceToolbox to fix BordersOut filter
      [backport] BUG: Update SlicerSurfaceToolbox to fix normals/smoothing/mirror filters

lassoan (5):
      [backport] ENH: Close DICOM browser when switching modules
      [backport] BUG: Fix regression in ScreenCapture module
      [backport] ENH: Made application icons show up nicer in dark mode
      [backport] BUG: Remove creation of DICOM browser widget before module is opened
      [backport] BUG: Fix volume rendered image position after cropping

sam.horvath (2):
      [backport] ENH  Reduce test timeout to 2 mins
      [backport] ENH:  Set test timeout to 15 minutes