### PR TITLE
BUG:  Fixed Windows Fortran packaging

### DIFF
--- a/CMake/CMakeLists.txt
+++ b/CMake/CMakeLists.txt
@@ -13,8 +13,8 @@ endif()
 
 # Download FindFortran.cmake
 set(dest_file "${CMAKE_CURRENT_BINARY_DIR}/FindFortran.cmake")
-set(expected_hash "924c90a47959e442f4304f62ce517e6bb17ab348432a14fc3861cf453b5d78ee")
-set(url "https://raw.githubusercontent.com/scikit-build/cmake-FindFortran/v0.5.2/FindFortran.cmake")
+set(expected_hash "fcb5e593ae9aea43697a7f02d6a0e08707b52ed71430ee7837ff11d5ed48e40f")
+set(url "https://raw.githubusercontent.com/scikit-build/cmake-FindFortran/v0.5.3/FindFortran.cmake")
 if(NOT EXISTS ${dest_file})
   file(DOWNLOAD ${url} ${dest_file} EXPECTED_HASH SHA256=${expected_hash})
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        551523bd112712f9b60ec7a48b8b2024d3ec0dbf # slicersalt-2018-11-16-15c897e
+  GIT_TAG        7368826c84ea46abf43266c2a007321484374750 # slicersalt-2019-10-03-15c897e
   GIT_PROGRESS   1
   QUIET
   )
@@ -387,7 +387,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        3d0d222f72f6340b3b672d4b6cd3b6aaa109902b # slicersalt-2019-10-02-4baa99c10
+  GIT_TAG        f147c9500b04fc978f28687be7796cb08f044b25 # slicersalt-2019-10-03-4baa99c10
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION
Updated FindFortran module to correctly include libomp.dll
Module updated in SALT, GROUPS, and SPHARM-PDM

Fixes #138 