### PR TITLE
ENH: Update SPV to fix Windows build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        90d8bdc5fe4ff321ed4d6dbe9ad394a2d2565871 # slicersalt-2018-11-26-92fb222
+  GIT_TAG        2974d3e645581993c225860e4014d4cb2932d7fc # slicersalt-2018-11-26-92fb222
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION
This fixes #212 

```
Jared Vicory (1):
      COMP: Pass _moc_options to QT5_WRAP_CPP
```

I'm running a clean build to verify but [this](https://github.com/slicersalt/ShapePopulationViewer/commit/2974d3e645581993c225860e4014d4cb2932d7fc) change seems to fix the build error on Windows.  I'm not sure why it doesn't seem to happen on Linux.