### PR TITLE
Update GROUPS and SPHARM-PDM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        60d892b60b88f51fec4876c5413c02b5549c9f21 # slicersalt-2020-06-09-60d892b
+  GIT_TAG        727cb3ccbe340d01c289b55cbe0f45e27dd64497 # slicersalt-2020-06-11-727cb3c
   GIT_PROGRESS   1
   QUIET
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        4b2d73548b94905d129d5f93b65139dec4e9c2f8 # slicersalt-2020-06-09-4b2d735
+  GIT_TAG        437c4ff6aea17c2139130ca1c7247ce8250f8863 # slicersalt-2018-11-16-15c897e
   GIT_PROGRESS   1
   QUIET
   )
@@ -387,7 +387,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        727cb3ccbe340d01c289b55cbe0f45e27dd64497 # slicersalt-2020-06-11-727cb3c
+  GIT_TAG        727cb3ccbe340d01c289b55cbe0f45e27dd64497 # slicersalt-2018-11-29-4baa99c10
   GIT_PROGRESS   1
   QUIET
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        7368826c84ea46abf43266c2a007321484374750 # slicersalt-2019-10-03-15c897e
+  GIT_TAG        4b2d73548b94905d129d5f93b65139dec4e9c2f8 # slicersalt-2020-06-09-4b2d735
   GIT_PROGRESS   1
   QUIET
   )
@@ -387,7 +387,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        50ae545559a9a897de60832e29a8062364cae7cf # slicersalt-2018-11-29-4baa99c10
+  GIT_TAG        60d892b60b88f51fec4876c5413c02b5549c9f21 # slicersalt-2020-06-09-60d892b
   GIT_PROGRESS   1
   QUIET
   )

--- a/Modules/Scripted/Home/CMakeLists.txt
+++ b/Modules/Scripted/Home/CMakeLists.txt
@@ -6,6 +6,7 @@ set(MODULE_PYTHON_RESOURCES
   "Resources/SampleDataDescription/DataImporterInputData.json"
   "Resources/SampleDataDescription/MFSDAInputData.json"
   "Resources/SampleDataDescription/SPHARM-PDMTestData.json"
+  "Resources/SampleDataDescription/SPHARM-PDMFiducials.json"
   "Resources/SampleDataDescription/ShapeRegressionInputData.json"
   "Resources/SampleDataDescription/SRepInitializerData.json"
   "Resources/SampleDataDescription/SVAInputData.json"

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -1,4 +1,5 @@
 import os
+import glob
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import (ScriptedLoadableModule,
                                            ScriptedLoadableModuleWidget)
@@ -112,6 +113,7 @@ The drop-down Modules are ordered to follow the basic workflow for choosing and 
             'MFSDAInputData.json',
             'ShapeRegressionInputData.json',
             'SPHARM-PDMTestData.json',
+            'SPHARM-PDMFiducials.json',
             'SRepInitializerData.json',
             'SVAInputData.json'
         ]:
@@ -206,7 +208,11 @@ The drop-down Modules are ordered to follow the basic workflow for choosing and 
             slicer.modules.DataImporterWidget.inputShapeAnalysisPath = outPath
         elif currModule == slicer.moduleNames.ShapeAnalysisModule:
             slicer.modules.ShapeAnalysisModuleWidget.GroupProjectInputDirectory.directory = destFolderPath
+            slicer.modules.ShapeAnalysisModuleWidget.RigidAlignmentFiducialsDirectory.directory = destFolderPath
             slicer.modules.ShapeAnalysisModuleWidget.GroupProjectOutputDirectory.directory = outPath
+            if glob.glob(os.path.join(destFolderPath, '*_fid.fcsv')):
+                slicer.modules.ShapeAnalysisModuleWidget.RigidAlignmentEnabled.checked = True
+                slicer.modules.ShapeAnalysisModuleWidget.CollapsibleButton_RigidAlignment.checked = True
         elif currModule == slicer.moduleNames.ShapeVariationAnalyzer:
             slicer.modules.ShapeVariationAnalyzerWidget.collapsibleButton_PCA.collapsed = False
             slicer.modules.ShapeVariationAnalyzerWidget.pathLineEdit_CSVFilePCA.currentPath = os.path.join(destFolderPath,'inputFiles.csv')

--- a/Modules/Scripted/Home/Resources/SampleDataDescription/SPHARM-PDMFiducials.json
+++ b/Modules/Scripted/Home/Resources/SampleDataDescription/SPHARM-PDMFiducials.json
@@ -1,0 +1,22 @@
+{
+    "category": "SPHARM-PDM",
+    "sampleName": "Correspondence Improvement",
+    "fileNames": [
+        "cilinder_seg_fid.fcsv",
+        "cilinder_seg.nrrd",
+        "hourglass_seg_fid.fcsv",
+        "hourglass_seg.nrrd"
+    ],
+    "uris": [
+        "https://data.kitware.com/api/v1/file/hashsum/sha512/ac53abe3580d9c1e8fdfd834eb9a834ff6b278e7bd00736e35c928046612c0b507f541f38d40ade400010a8db2b54090d3816194fa40bfdd2a82b98d30359402/download",
+        "https://data.kitware.com/api/v1/file/hashsum/sha512/a2fc007967f0ced1db73dbe5b46eac2dbbef371cb3a5874d5df83ce6b6063912c34e2208acdbd0fd1adda5e2f98f229ce7487f616145160fcda67f1742a475d5/download",
+        "https://data.kitware.com/api/v1/file/hashsum/sha512/4246870056226bf224bee687c264f378f6b09a13c22b0f8e7e10fcc7f8590599cbf9308716fcd77edb9f08a99d639e3536c933a61c433d65aac36af15aff5ee4/download",
+        "https://data.kitware.com/api/v1/file/hashsum/sha512/42ec3bf37d1f87fa2c6ec0859af441cf9ed0da5d81e2c90c11a4b093e0a197afc81266e3e19331748627a3dbe0cc8bc6c2b9db31900be1d8bf50ff549ca683d9/download"
+    ],
+    "checksums": [
+        "SHA512:ac53abe3580d9c1e8fdfd834eb9a834ff6b278e7bd00736e35c928046612c0b507f541f38d40ade400010a8db2b54090d3816194fa40bfdd2a82b98d30359402",
+        "SHA512:a2fc007967f0ced1db73dbe5b46eac2dbbef371cb3a5874d5df83ce6b6063912c34e2208acdbd0fd1adda5e2f98f229ce7487f616145160fcda67f1742a475d5",
+        "SHA512:4246870056226bf224bee687c264f378f6b09a13c22b0f8e7e10fcc7f8590599cbf9308716fcd77edb9f08a99d639e3536c933a61c433d65aac36af15aff5ee4",
+        "SHA512:42ec3bf37d1f87fa2c6ec0859af441cf9ed0da5d81e2c90c11a4b093e0a197afc81266e3e19331748627a3dbe0cc8bc6c2b9db31900be1d8bf50ff549ca683d9"
+    ]
+}

--- a/Modules/Scripted/Home/Resources/SampleDataDescription/SPHARM-PDMTestData.json
+++ b/Modules/Scripted/Home/Resources/SampleDataDescription/SPHARM-PDMTestData.json
@@ -1,6 +1,6 @@
 {
     "category": "SPHARM-PDM",
-    "sampleName": "Download sample data",
+    "sampleName": "Basic sample data",
     "fileNames": [
         "InputImage.nrrd"
     ],


### PR DESCRIPTION
There are associated branches in the GROUPS, SPHARM-PDM, and RigidAlignment repositories as well. This commit updates the tags that SlicerSALT refers to.

https://github.com/slicersalt/GROUPS/tree/slicersalt-2020-06-09-4b2d735
https://github.com/slicersalt/SPHARM-PDM/tree/slicersalt-2020-06-09-60d892b
https://github.com/slicersalt/RigidAlignment/tree/slicersalt-2020-06-09-9386fdb

RigidAlignment is pulled in through GROUPS; a similar update has been made there.