### PR TITLE
Update Slicer to 4.11.20200930 Stable

### DIFF
--- a/Applications/SlicerSALTApp/qSlicerSALTAppMainWindow.cxx
+++ b/Applications/SlicerSALTApp/qSlicerSALTAppMainWindow.cxx
@@ -97,10 +97,7 @@ void qSlicerSALTAppMainWindowPrivate::setupUi(QMainWindow * mainWindow)
 
   qSlicerModulesMenu* modulesMenu = this->ModuleSelectorToolBar->modulesMenu();
 
-  ctkMenuComboBox* modulesMenuComboBox = this->ModuleSelectorToolBar->modulesMenuComboBox();
-  modulesMenuComboBox->setCompleterMenu(modulesMenu->allModulesCategory());
-
-  modulesMenu->setAllModulesCategoryVisible(false);
+  
 
   modulesMenu->setTopLevelCategoryOrder(
         QStringList()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,22 +193,6 @@ FetchContent_Populate(${extension_name}
   )
 list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
 
-#-----------------------------------------------------------------------------
-# Sequences
-
-set(SEQUENCES_ENABLE_SAMPLEDATA_MODULE OFF)
-mark_as_superbuild(SEQUENCES_ENABLE_SAMPLEDATA_MODULE:BOOL)
-
-set(extension_name "Sequences")
-set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
-FetchContent_Populate(${extension_name}
-  SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
-  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/SlicerRt/${extension_name}
-  GIT_TAG        c4656de3184cff8ea86c5ca8b4737040db49a980
-  GIT_PROGRESS   1
-  QUIET
-  )
-list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
 
 #-----------------------------------------------------------------------------
 # Srep

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,7 +368,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        727cb3ccbe340d01c289b55cbe0f45e27dd64497 # slicersalt-2018-11-29-4baa99c10
+  GIT_TAG        d31cbec24be78151032119653321d8ab55fa538f # slicersalt-2020-04-27-47188484c
   GIT_PROGRESS   1
   QUIET
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/slicersalt/Slicer
-    GIT_TAG        8a9b704362f35e182a22852409abd9c6a8aa0ae2 # slicersalt-4.11-2019-09-04-933a0785f
+    GIT_TAG        3a4b267b5c0367cc7f3f21848232d684a251d31c # slicersalt-4.11-2020-09-30-002be180
     GIT_PROGRESS   1
     )
 else()

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -41,22 +41,7 @@ class Home(ScriptedLoadableModule):
         </center>
         """
 
-        slicer.app.connect("startupCompleted()", self.updateModulesMenu)
-
-    def updateModulesMenu(self):
-        moduleMenu = slicer.util.mainWindow().moduleSelector().modulesMenu()
-
-        moduleMenu.removeCategory("Developer Tools")
-        moduleMenu.removeCategory("Diffusion")
-        moduleMenu.removeCategory("Converters")
-        moduleMenu.removeCategory("Registration.Specialized")
-        moduleMenu.removeCategory("Segmentation")
-
-        removeFromAllModules = False
-        moduleMenu.removeModule("SegmentEditor", removeFromAllModules)
-        moduleMenu.removeModule("Segmentations", removeFromAllModules)
-        moduleMenu.removeModule("Terminologies", removeFromAllModules)
-
+        
 
 #
 # HomeWidget


### PR DESCRIPTION
@bpaniagua 

This updates to the Slicer stable, with no modifications yet.  The only build issue is SPHARM-PDM (error below).  We had previously addressed this by not using ITK 5, but we should go ahead and get this fixed now.  I have most of the changes needed (I think) on this branch here:  https://github.com/slicersalt/SPHARM-PDM/commits/slicersalt-2020-04-27-47188484c

SALT is currently using this less recent branch:   https://github.com/slicersalt/SPHARM-PDM/commits/slicersalt-2018-11-29-4baa99c10

Should I go ahead and try to resolve these branches?

````
D:\D\E\SA-2-build\ITK\Modules\Core\Common\include\itkExceptionObject.h(19): fatal error C1189: #error:  "Do not include itkExceptionO
bject.h directly,  include itkMacro.h instead." (compiling source file D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\Algorithms\Spheri 
calHarmonicMeshSource.cxx) [D:\D\E\SA-2-build\Slicer-build\E\SPHARM-PDM\Libraries\Shape\Algorithms\ShapeAlgorithms.vcxproj]
D:\D\E\SA-2-build\ITK\Modules\Core\Common\include\itkExceptionObject.h(19): fatal error C1189: #error:  "Do not include itkExceptionO
bject.h directly,  include itkMacro.h instead." (compiling source file D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\Algorithms\Spheri 
calHarmonicMedialAxisMeshSource.cxx) [D:\D\E\SA-2-build\Slicer-build\E\SPHARM-PDM\Libraries\Shape\Algorithms\ShapeAlgorithms.vcxproj]
D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\SpatialObject\SphericalHarmonicSpatialObject.h(88): error C3668: 'neurolib::SphericalHar
monicSpatialObject::ValueAt': method with override specifier 'override' did not override any base class methods (compiling source fil
e D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\Algorithms\ParametricMeshToSPHARMSpatialObjectFilter.cxx) [D:\D\E\SA-2-build\Slicer-bu 
ild\E\SPHARM-PDM\Libraries\Shape\Algorithms\ShapeAlgorithms.vcxproj]
D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\SpatialObject\SphericalHarmonicSpatialObject.h(90): error C3668: 'neurolib::SphericalHar 
monicSpatialObject::IsEvaluableAt': method with override specifier 'override' did not override any base class methods (compiling sour
ce file D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\Algorithms\ParametricMeshToSPHARMSpatialObjectFilter.cxx) [D:\D\E\SA-2-build\Sli 
cer-build\E\SPHARM-PDM\Libraries\Shape\Algorithms\ShapeAlgorithms.vcxproj]
D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\SpatialObject\SphericalHarmonicSpatialObject.h(92): error C3668: 'neurolib::SphericalHar 
monicSpatialObject::IsInside': method with override specifier 'override' did not override any base class methods (compiling source fi 
le D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\Algorithms\ParametricMeshToSPHARMSpatialObjectFilter.cxx) [D:\D\E\SA-2-build\Slicer-b 
uild\E\SPHARM-PDM\Libraries\Shape\Algorithms\ShapeAlgorithms.vcxproj]
D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\SpatialObject\SphericalHarmonicSpatialObject.h(97): error C3668: 'neurolib::SphericalHar 
monicSpatialObject::ComputeLocalBoundingBox': method with override specifier 'override' did not override any base class methods (comp
iling source file D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\Algorithms\ParametricMeshToSPHARMSpatialObjectFilter.cxx) [D:\D\E\SA-2 
-build\Slicer-build\E\SPHARM-PDM\Libraries\Shape\Algorithms\ShapeAlgorithms.vcxproj]
D:\D\E\SA-2-build\ITK\Modules\Core\Common\include\itkExceptionObject.h(19): fatal error C1189: #error:  "Do not include itkExceptionO 
bject.h directly,  include itkMacro.h instead." (compiling source file D:\D\E\SA-2-build\SPHARM-PDM\Libraries\Shape\Algorithms\Parame 
tricMeshToSPHARMSpatialObjectFilter.cxx) [D:\D\E\SA-2-build\Slicer-build\E\SPHARM-PDM\Libraries\Shape\Algorithms\ShapeAlgorithms.vcxp 
roj]
````