### PR TITLE
ENH: Update s-rep repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${short_extension_name}")
 FetchContent_Populate(${short_extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/KitwareMedical/SlicerSkeletalRepresentation.git
-  GIT_TAG        f757b711b74fa8d35dacb7345b895a97746c58ca
+  GIT_TAG        002244d83c44444235909f73194d7b1f3f0c8635 
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION
Jared Vicory (4):
      Fix bug causing strange s-rep meshes
      Add module to allow initializing s-reps from SPHARM models
      ENH: Update SPHARM initialization
      BUG: Fix Mac compilation error

vicory (2):
      Merge pull request #42 from vicory/add_spharm_code
      Merge pull request #43 from vicory/add_spharm_code