### PR TITLE
ENH: Update SVA and Procrustes repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/${extension_name}
-  GIT_TAG        9eb71073e4e782ab9a44f3ba708793735ac0c9c4 # slicersalt-2020-07-22-9eb7107
+  GIT_TAG        02e56a2096ac5962215e3badeedd3f6b64553eb2 # slicersalt-2020-07-22-9eb7107
   GIT_PROGRESS   1
   QUIET
   )
@@ -268,7 +268,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${short_extension_name}")
 FetchContent_Populate(${short_extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/slicersalt/ProcrustesRegistrationModule.git
-  GIT_TAG        2dad32e9761def182e8df89dec2fe30cc3b87d5d
+  GIT_TAG        52ece6b958904ff2199d1f4981e8d64c74f4c4bb
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION
@bpaniagua @vicory Please review and merge/upload to data.kitware.com if this works. I will publish the blog after that.

Meanwhile I got the following build error this morning which is due to the testing data website down. 
`CMake Error at /home/yehan/Kitware/SlicerSALT-build/slicersources-src/CMake/ExternalData.cmake:1113 (message):
  Object MD5=3666cc8160c47307192f6d895574a390 not found at:
https://github.com/Slicer/SlicerTestingData/releases/download/MD5/3666cc8160c47307192f6d895574a390 ("HTTP response code said error")
    http://slicer.kitware.com/midas3/api/rest?method=midas.bitstream.download&checksum=3666cc8160c47307192f6d895574a390 (wrong hash MD5=50928178198297b8e2a3a58e2af4c7ba)
    http://slicer.kitware.com/midas3/api/rest?method=midas.bitstream.download&checksum=3666cc8160c47307192f6d895574a390 (wrong hash MD5=50928178198297b8e2a3a58e2af4c7ba)
make[5]: *** [E/MeshToLabelMap/Testing/CMakeFiles/MeshToLabelMapData.dir/build.make:81: Testing/Data/Input/model.vtk-hash-stamp] Error 1
`