### PR TITLE
Temporarily disable MeshToLabelMap testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,8 +186,8 @@ set(extension_name "MeshToLabelMap")
 set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
-  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/NIRALUser/${extension_name}
-  GIT_TAG        9e2e199b99396c570f5f26c0ccfd5e149f6b9d34
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/vicory/${extension_name}
+  GIT_TAG        8995dc3163ec4dbbf71948f4d2625badfe01abf2
   GIT_PROGRESS   1
   QUIET
   )


### PR DESCRIPTION
This is just a temporary fix until we can move MeshToLabelMap testing data that used to be on midas.