### PR TITLE
COMP: Fix macOS notarization setting Slicer_MACOSX_BUNDLE_GUI_IDENTIFIER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,11 @@ endif()
 include(SlicerInitializeBuildType)
 include(SlicerInitializeReleaseType)
 
+# Set application bundle identifier for macOS
+if(APPLE)
+  set(Slicer_MACOSX_BUNDLE_GUI_IDENTIFIER "com.kitware.slicersalt")
+endif()
+
 # Installation folder and admin account requirement for Windows
 if(WIN32)
   # Note: To avoid escaping issue, make sure to use forward slash when setting


### PR DESCRIPTION
Based of the following commits:

* KitwareMedical/SlicerCustomAppTemplate@bdcb062f6
  `COMP: Set Slicer_MACOSX_BUNDLE_GUI_IDENTIFIER`

* Slicer/Slicer@4425da860
  `COMP: Fix application notarization on macOS setting bundle identifier`

Since the `slicer-macos-codesign-scripts` can be locally modified to force the update of the identifier [^1], this is not required for the current `4.0.1` release of SlicerSALT.

[^1]: https://github.com/KitwareMedical/slicer-macos-codesign-scripts/pull/1