### PR TITLE
TEST: Temorarily disable unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 
 
 # Slicer options
-option(BUILD_TESTING                            "Build application test suite"                        ON)
+option(BUILD_TESTING                            "Build application test suite"                        OFF)
 option(Slicer_BUILD_DOCUMENTATION               "Build documentation (Doxygen, sphinx, ...)"          OFF)
 if(WIN32)
   option(Slicer_BUILD_WIN32_CONSOLE             "Build application executable as a console app"       OFF)


### PR DESCRIPTION
This is being done to temporarily work around an issue with package sizes for the 5.0 release.

Should be reverted after we fix the issue upstream in the SlicerSurfaceLearner extension